### PR TITLE
Use re instead of QRegExp in highlighter.py for Qt6 compatibility.

### DIFF
--- a/pyqtconsole/highlighter.py
+++ b/pyqtconsole/highlighter.py
@@ -141,13 +141,14 @@ class PythonHighlighter(QSyntaxHighlighter):
                 add = m.end() - m.start()
             else:
                 start = -1
+                add = -1
 
         # As long as there's a delimiter match on this line...
         while start >= 0:
             # Look for the ending delimiter
             m = delimiter.search(text, start + add)
             # Ending delimiter on this line?
-            if m and ((end := m.start()) >= add):
+            if m and (m.start() >= add):
                 # length = end - start + add + m.end() - m.start()
                 length = add + m.end() - start
                 self.setCurrentBlockState(0)

--- a/pyqtconsole/highlighter.py
+++ b/pyqtconsole/highlighter.py
@@ -1,7 +1,7 @@
-from qtpy.QtCore import QRegExp
 from qtpy.QtGui import (QColor, QTextCharFormat, QFont, QSyntaxHighlighter)
 
 import keyword
+import re
 
 
 def format(color, style=''):
@@ -42,20 +42,16 @@ class PromptHighlighter(object):
         self.styles = styles = dict(STYLES, **(formats or {}))
         self.rules = [
             # Match the prompt incase of a console
-            (QRegExp(r'IN[^\:]*'), 0, styles['inprompt']),
-            (QRegExp(r'OUT[^\:]*'), 0, styles['outprompt']),
+            (re.compile(r'IN[^\:]*'), 0, styles['inprompt']),
+            (re.compile(r'OUT[^\:]*'), 0, styles['outprompt']),
             # Numeric literals
-            (QRegExp(r'\b[+-]?[0-9]+\b'), 0, styles['numbers']),
+            (re.compile(r'\b[+-]?[0-9]+\b'), 0, styles['numbers']),
         ]
 
     def highlight(self, text):
         for expression, nth, format in self.rules:
-            index = expression.indexIn(text, 0)
-            while index >= 0:
-                index = expression.pos(nth)
-                length = len(expression.cap(nth))
-                yield (index, length, format)
-                index = expression.indexIn(text, index + length)
+            for m in expression.finditer(text):
+                yield (m.start(nth), m.end(nth) - m.start(nth), format)
 
 
 class PythonHighlighter(QSyntaxHighlighter):
@@ -72,8 +68,8 @@ class PythonHighlighter(QSyntaxHighlighter):
         # Multi-line strings (expression, flag, style)
         # FIXME: The triple-quotes in these two lines will mess up the
         # syntax highlighting from this point onward
-        self.tri_single = (QRegExp("'''"), 1, styles['string2'])
-        self.tri_double = (QRegExp('"""'), 2, styles['string2'])
+        self.tri_single = (re.compile("'''"), 1, styles['string2'])
+        self.tri_double = (re.compile('"""'), 2, styles['string2'])
 
         rules = []
 
@@ -106,8 +102,8 @@ class PythonHighlighter(QSyntaxHighlighter):
              styles['numbers']),
         ]
 
-        # Build a QRegExp for each pattern
-        self.rules = [(QRegExp(pat), index, fmt)
+        # Build a regex object for each pattern
+        self.rules = [(re.compile(pat), index, fmt)
                       for (pat, index, fmt) in rules]
 
     def highlightBlock(self, text):
@@ -115,14 +111,8 @@ class PythonHighlighter(QSyntaxHighlighter):
         """
         # Do other syntax formatting
         for expression, nth, format in self.rules:
-            index = expression.indexIn(text, 0)
-
-            while index >= 0:
-                # We actually want the index of the nth match
-                index = expression.pos(nth)
-                length = len(expression.cap(nth))
-                self.setFormat(index, length, format)
-                index = expression.indexIn(text, index + length)
+            for m in expression.finditer(text):
+                self.setFormat(m.start(nth), m.end(nth) - m.start(nth), format)
 
         self.setCurrentBlockState(0)
 
@@ -133,7 +123,7 @@ class PythonHighlighter(QSyntaxHighlighter):
 
     def match_multiline(self, text, delimiter, in_state, style):
         """Do highlighting of multi-line strings. ``delimiter`` should be a
-        ``QRegExp`` for triple-single-quotes or triple-double-quotes, and
+        ``re.Pattern`` for triple-single-quotes or triple-double-quotes, and
         ``in_state`` should be a unique integer to represent the corresponding
         state changes when inside those strings. Returns True if we're still
         inside a multi-line string when this function is finished.
@@ -144,17 +134,22 @@ class PythonHighlighter(QSyntaxHighlighter):
             add = 0
         # Otherwise, look for the delimiter on this line
         else:
-            start = delimiter.indexIn(text)
-            # Move past this match
-            add = delimiter.matchedLength()
+            m = delimiter.search(text)
+            if m:
+                start = m.start()
+                # Move past this match
+                add = m.end() - m.start()
+            else:
+                start = -1
 
         # As long as there's a delimiter match on this line...
         while start >= 0:
             # Look for the ending delimiter
-            end = delimiter.indexIn(text, start + add)
+            m = delimiter.search(text, start + add)
             # Ending delimiter on this line?
-            if end >= add:
-                length = end - start + add + delimiter.matchedLength()
+            if m and ((end := m.start()) >= add):
+                # length = end - start + add + m.end() - m.start()
+                length = add + m.end() - start
                 self.setCurrentBlockState(0)
             # No; multi-line string
             else:
@@ -163,7 +158,11 @@ class PythonHighlighter(QSyntaxHighlighter):
             # Apply formatting
             self.setFormat(start, length, style)
             # Look for the next match
-            start = delimiter.indexIn(text, start + length)
+            m = delimiter.search(text, start + length)
+            if m:
+                start = m.start()
+            else:
+                break
 
         # Return True if still inside a multi-line string, False otherwise
         return self.currentBlockState() == in_state


### PR DESCRIPTION
This should fix #76, while still allowing it to work with Qt4 and Qt5.