### PR TITLE
Updated supported Python versions

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -9,10 +9,11 @@ jobs:
       fail-fast: false
       matrix:
         python:
-          - "3.7"
           - "3.8"
           - "3.9"
           - "3.10"
+          - "3.11"
+          - "3.12"
         os:
           - macos-latest
           - ubuntu-latest

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -9,14 +9,13 @@ authors = [
     {name = "Marcus Oskarsson", email = "marcus.oscarsson@esrf.fr"}
 ]
 description = "Light-weight python interpreter, easy to embed into Qt applications"
-requires-python = ">=2.7"
+requires-python = ">=3.8"
 keywords = ["interactive", "interpreter", "console", "shell", "autocompletion", "jedi", "qt"]
 license = {text = "MIT"}
 classifiers = [
     "Environment :: X11 Applications :: Qt",
     "Intended Audience :: Developers",
     "Operating System :: OS Independent",
-    "Programming Language :: Python :: 2.7",
     "Programming Language :: Python :: 3",
     "Topic :: Software Development :: Interpreters",
     "Topic :: Software Development :: User Interfaces",


### PR DESCRIPTION
~~(Should merge #80 first and rebase)~~

I think it's about time to drop support for Python 2.7 and 3.7 (if they were still working to begin with). Python 3.7 reached [end-of-life last year](https://devguide.python.org/versions/).

EDIT: Checks are passing, I'm not expecting problems with Python 3.11 and 3.12.